### PR TITLE
change to escape(..)

### DIFF
--- a/mime.js
+++ b/mime.js
@@ -194,7 +194,7 @@ this.decodeQuotedPrintable = function(str, mimeWord, charset){
         str = str.replace(/=$/,"");
     }
     if(charset == "UTF-8")
-        str = decodeURIComponent(str.replace(/=/g,"%"));
+        str = unescape(str.replace(/=/g,"%"));
     else{
         str = str.replace(/=/g,"%");
         if(charset=="ISO-8859-1" || charset=="LATIN1")


### PR DESCRIPTION
fix error with trying to URI decode something that is not a URI (seems like a bug in mailparser)

this is the only way i can make my emails work because they are in UTF-8. message me if you would like a sample email that only works after this change.
