### PR TITLE
Decode mime word with charset not UTF8

### DIFF
--- a/mime.js
+++ b/mime.js
@@ -190,7 +190,7 @@ this.decodeQuotedPrintable = function(str, mimeWord, charset){
     if(mimeWord){
         str = str.replace(/_/g," ");
     }else{
-        str = str.replace(/=\r\n/gm,'');
+        str = str.replace(/=\r?\n/gm,'');
         str = str.replace(/=$/,"");
     }
     if(charset == "UTF-8")

--- a/test/mime.test.js
+++ b/test/mime.test.js
@@ -36,5 +36,8 @@ module.exports = {
     },
     "test decode mime word with charset GB2312": function() {
 	assert.equal(mime.decodeMimeWord("=?GB2312?Q?Test_for_=D6=D0=CE=C4?="), "Test for 中文");
+    },
+    "test decode quoted printable": function() {
+	assert.equal(mime.decodeQuotedPrintable("Test for chinese\n=E4=BA=BA =\n=E6=B0=91", false), "Test for chinese\n人 民");
     }
 }


### PR DESCRIPTION
The mime lib can't post the charset param to decodeBase64 when decodeMimeWord.
And can't recognize line separator "\n" when decodeQuotedPrintable
