### PR TITLE
make parseBody could handle feed data like a single "\r\n".

### DIFF
--- a/mailparser.js
+++ b/mailparser.js
@@ -272,9 +272,14 @@ MailParser.prototype.parseBody = function(data){
 
                 // handle headers
                 if(!this.body.headerStrComplete){
-                    if((pos2 = data.indexOf("\r\n\r\n", pos))>=0){
-                        this.body.headerStr += data.substring(pos, pos2);
-                        pos = pos2+4;
+                    if(
+                        (pos2 = data.indexOf("\r\n\r\n", pos)) >= 0
+                        || this.body.headerStr.indexOf("\r\n\r\n") >= 0
+                    ){
+                        if(pos2 >=0){
+                            this.body.headerStr += data.substring(pos, pos2);
+                            pos = pos2+4;
+                        }
                         this.body.headerStrComplete = true;
                         this.body.headerObj = mime.parseHeaders(this.body.headerStr.trim());
 


### PR DESCRIPTION
I'm using mailparser with smtp (https://github.com/aredridel/node-smtp) as a incoming email server just like this

``` javascript
var smtp = require('smtp');

smtp.createServer(function(connection) {
    connection.on('DATA', function(message) {
       var MailParser = require('mailparser').MailParser;
       var mp = new MailParser();
       mp.on("body", function(body){
         console.log("!!! body");
       }); 
       message.on('data', function(data) {
         mp.feed(data);
       });
       message.on('end', function() {
         mp.end();
         message.accept()
       });      
    });
}).listen(25);

console.log("SMTP server running on port 25");
```

But it doesn't work like I expected.

The reason is smtp will fire `data` event each line of the incoming mail. So this line `data.indexOf("\r\n\r\n", pos)` will never match, because the value of data could be `"\r\n"`. I just add some code to handle that case.
