### PR TITLE
Add messageId to the final object

### DIFF
--- a/lib/mailparser.js
+++ b/lib/mailparser.js
@@ -478,6 +478,7 @@ MailParser.prototype._processHeaderLine = function(pos){
             break;
         case "message-id":
             this._currentNode.meta.messageId = this._trimQuotes(value);
+            this._currentNode.messageId = this._currentNode.meta.messageId;
             break;
         case "references":
             this._parseReferences(value);
@@ -927,6 +928,10 @@ MailParser.prototype._processMimeTree = function(){
 
     if(this.mimeTree.references){
         returnValue.references = this.mimeTree.references;
+    }
+
+    if(this.mimeTree.messageId){
+        returnValue.messageId = this.mimeTree.messageId;   
     }
 
     if(this.mimeTree.inReplyTo){


### PR DESCRIPTION
I'm not sure if this make sense to you, but it's very useful to have the (unquoted) message-id header inside as a property on the object, first of all because (as described in [RFC 2822](http://www.ietf.org/rfc/rfc2822.txt)) message-id is semantically related to 'in-reply-to' and 'references' fields.
