### PR TITLE
Handle text/calendar alternatives

### DIFF
--- a/lib/mailparser.js
+++ b/lib/mailparser.js
@@ -878,7 +878,7 @@ MailParser.prototype._finalizeContents = function(){
             }
         }else{
             if(this._currentNode.meta.transferEncoding == "quoted-printable"){
-                this._currentNode.content = mimelib.decodeQuotedPrintable(this._currentNode.content, false, "utf-8");
+                this._currentNode.content = mimelib.decodeQuotedPrintable(this._currentNode.content, false, "binary");
             }else if(this._currentNode.meta.transferEncoding == "base64"){
 
                 // WTF? if newlines are not removed, the resulting hash is *always* different


### PR DESCRIPTION
This is an update to handle text/calendar alternative nodes, and place them into an alternatives array. 

See bug filed here: https://github.com/andris9/mailparser/issues/82
