### PR TITLE
Improve header parser to not split quoted strings

### DIFF
--- a/lib/mailparser.js
+++ b/lib/mailparser.js
@@ -573,7 +573,7 @@ MailParser.prototype._createMimeNode = function(parentNode){
 MailParser.prototype._parseHeaderLineWithParams = function(value){
     var key, parts, returnValue = {};
 
-    parts = value.split(";");
+    parts = value.match(/(?:[^;"]+|"[^"]*")+/g);
     returnValue.defaultValue = parts.shift().toLowerCase();
 
     for(var i=0, len = parts.length; i<len; i++){

--- a/test/mailparser.js
+++ b/test/mailparser.js
@@ -675,6 +675,23 @@ exports["Attachment filename"] = {
             test.equal(mail.attachments && mail.attachments[0] && mail.attachments[0].content && mail.attachments[0].generatedFileName, "attachment.pdf");
             test.done();
         });
+    },
+    "Filename with semicolon": function(test){
+        var encodedText = "Content-Type: multipart/mixed; boundary=ABC\r\n"+
+                          "\r\n"+
+                          "--ABC\r\n"+
+                              "Content-Disposition: attachment; filename=\"hello;world;test.txt\"\r\n"+
+                              "\r\n"+
+                              "=00=01=02=03=FD=FE=FF\r\n"+
+                          "--ABC--",
+            mail = new Buffer(encodedText, "utf-8");
+
+        var mailparser = new MailParser();
+        mailparser.end(mail);
+        mailparser.on("end", function(mail){
+            test.equal(mail.attachments && mail.attachments[0] && mail.attachments[0].content && mail.attachments[0].generatedFileName, "hello;world;test.txt");
+            test.done();
+        });
     }
 
 };


### PR DESCRIPTION
Fixes a bug where an attachment filename has a semicolon in it
