### PR TITLE
Added '7bit' to possible body content-transfer-encodings, treating it th...

### DIFF
--- a/lib/mailparser.js
+++ b/lib/mailparser.js
@@ -862,7 +862,8 @@ MailParser.prototype._finalizeContents = function(){
                  this._currentNode.meta.charset = this._detectHTMLCharset(this._currentNode.content) || this._currentNode.meta.charset || this.options.defaultCharset || "iso-8859-1";
             }
 
-            if(this._currentNode.meta.transferEncoding == "quoted-printable"){
+            if(this._currentNode.meta.transferEncoding == "quoted-printable" ||
+               this._currentNode.meta.transferEncoding == "7bit"){
                 this._currentNode.content = mimelib.decodeQuotedPrintable(this._currentNode.content, false, this._currentNode.meta.charset || this.options.defaultCharset || "iso-8859-1");
                 if(this._currentNode.meta.textFormat == "flowed"){
                     if(this._currentNode.meta.textDelSp == "yes"){


### PR DESCRIPTION
...e same as quoted-printable

Hi andris,
Here is the second of my pull requests (the first was for your encoding library). It adds a line to decode Content-Transfer-Encoding: 7bit as quoted-printable when finalizing body text. I don't know if this is the right way to do it, but I had some Japanese emails sent from iPhones that wouldn't get decoded because 7bit wasn't a possible case in _finalizeContents.
It's a one-line change, and I hope you can make use of it!
