### PR TITLE
Remove 1 letter length limitation from decoding mime words

### DIFF
--- a/lib/mailparser.js
+++ b/lib/mailparser.js
@@ -1284,8 +1284,8 @@ MailParser.prototype._encodeString = function(value) {
  */
 MailParser.prototype._replaceMimeWords = function(value) {
     return value.
-    replace(/(=\?[^?]+\?[QqBb]\?[^?]+\?=)\s+(?==\?[^?]+\?[QqBb]\?[^?]+\?=)/g, "$1"). // join mimeWords
-    replace(/\=\?[^?]+\?[QqBb]\?[^?]+\?=/g, (function(a) {
+    replace(/(=\?[^?]+\?[QqBb]\?[^?]*\?=)\s+(?==\?[^?]+\?[QqBb]\?[^?]*\?=)/g, "$1"). // join mimeWords
+    replace(/\=\?[^?]+\?[QqBb]\?[^?]*\?=/g, (function(a) {
         return mimelib.decodeMimeWord(a.replace(/\s/g, ''));
     }).bind(this));
 };

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     }
   ],
   "dependencies": {
-    "mimelib": ">=0.2.6",
+    "mimelib": ">=0.2.17",
     "encoding": ">=0.1.4",
     "mime": "*",
     "uue": "~1.0.0"

--- a/test/mailparser.js
+++ b/test/mailparser.js
@@ -368,6 +368,8 @@ exports["Text encodings"] = {
     },
     "Mime Words": function(test){
         var encodedText = "Content-type: text/plain; charset=utf-8\r\n" +
+                          "From: =?utf-8?q??= <sender@email.com>\r\n" +
+                          "To: =?ISO-8859-1?Q?Keld_J=F8rn_Simonsen?= <to@email.com>\r\n" +
                           "Subject: =?iso-8859-1?Q?Avaldu?= =?iso-8859-1?Q?s_lepingu_?=\r\n =?iso-8859-1?Q?l=F5petamise?= =?iso-8859-1?Q?ks?=\r\n",
             mail = new Buffer(encodedText, "utf-8");
 
@@ -375,6 +377,8 @@ exports["Text encodings"] = {
         mailparser.end(mail);
         mailparser.on("end", function(mail){
             test.equal(mail.subject, "Avaldus lepingu lõpetamiseks");
+            test.equal(mail.from[0].name, "");
+            test.equal(mail.to[0].name, "Keld Jørn Simonsen");
             test.done();
         });
     }


### PR DESCRIPTION
Removes 1 letter length requirement from decodeMimeWord. This enables
decoding empty strings which sometimes may be sent out via mass mailers.
