### PR TITLE
Call to nonexisting method on Buffer instance

### DIFF
--- a/lib/mailparser.js
+++ b/lib/mailparser.js
@@ -892,7 +892,7 @@ MailParser.prototype._finalizeContents = function() {
             } else if (this._currentNode.meta.transferEncoding == "base64") {
 
                 // WTF? if newlines are not removed, the resulting hash is *always* different
-                this._currentNode.content = new Buffer(this._currentNode.content.replace(/\s+/g, ""), "base64");
+                this._currentNode.content = new Buffer(this._currentNode.content.toString().replace(/\s+/g, ""), "base64");
 
             } else if (this._currentNode.meta.transferEncoding == "uuencode") {
                 var uuestream = new Streams.UUEStream("binary");


### PR DESCRIPTION
this._currentNode.content is a Buffer object which has no .replace method
