### PR TITLE
Fix parsing for missing quotes around cid

### DIFF
--- a/lib/mail-parser.js
+++ b/lib/mail-parser.js
@@ -745,7 +745,7 @@ class MailParser extends Transform {
         let cids = new Map();
         let html = (this.html || '').toString();
 
-        html.replace(/\bcid:([^'"]{1,256})/g, (match, cid) => {
+        html.replace(/\bcid:([^'"\s]{1,256})/g, (match, cid) => {
             for (let i = 0, len = this.attachmentList.length; i < len; i++) {
                 if (this.attachmentList[i].cid === cid && /^image\/[\w]+$/i.test(this.attachmentList[i].contentType)) {
                     if (/^image\/[\w]+$/i.test(this.attachmentList[i].contentType)) {
@@ -767,7 +767,7 @@ class MailParser extends Transform {
         let pos = 0;
         let processNext = () => {
             if (pos >= cidList.length) {
-                html = html.replace(/\bcid:([^'"]{1,256})/g, (match, cid) => {
+                html = html.replace(/\bcid:([^'"\s]{1,256})/g, (match, cid) => {
                     if (cids.has(cid) && cids.get(cid).url) {
                         return cids.get(cid).url;
                     }


### PR DESCRIPTION
If the eMail is missing quotes around the cid in an image tag, the
current regex fails to extract only the cid:

`<img src=cid:f2d00d7e00ca0aa64 width="200" height="300" />`

would lead to `cid:f2d00d7e00ca0aa64 width=` which in turn does not get
replaced later. By adding whitespace to the regex pattern, this is
fixed.