### PR TITLE
incorrect method call in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ parser.on('data', data => {
     if(data.type === 'attachment'){
         console.log(data.filename);
         data.content.pipe(process.stdout);
-        data.on('end', ()=>data.release());
+        data.content.on('end', ()=>data.release());
     }
 });
 ```


### PR DESCRIPTION
fixes: TypeError: data.on is not a function

``` js
/Users/dave/dev/node-qsee-alerts/qsee-alerts.js:55
            data.on('end', function () {
                 ^

TypeError: data.on is not a function
    at MailParser.<anonymous> (/Users/dave/dev/node-qsee-alerts/qsee-alerts.js:55:18)
    at emitOne (events.js:96:13)
    at MailParser.emit (events.js:189:7)
    at readableAddChunk (_stream_readable.js:176:18)
    at MailParser.Readable.push (_stream_readable.js:134:10)
    at MailParser.Transform.push (_stream_transform.js:128:32)
    at MailParser.processChunk (/Users/dave/dev/node-qsee-alerts/node_modules/mailparser/lib/mail-parser.js:616:30)
    at MailParser.readData (/Users/dave/dev/node-qsee-alerts/node_modules/mailparser/lib/mail-parser.js:86:14)
    at Immediate.setImmediate (/Users/dave/dev/node-qsee-alerts/node_modules/mailparser/lib/mail-parser.js:93:37)
    at runCallback (timers.js:651:20)
```