### PR TITLE
fix url encoding in textToHtml function

### DIFF
--- a/lib/mail-parser.js
+++ b/lib/mail-parser.js
@@ -853,19 +853,7 @@ function textToHtml(str) {
                     result.push(encoded.slice(last, link.index));
                 }
 
-                let url = he
-                    // encode special chars
-                    .encode(link.url, {
-                        useNamedReferences: true
-                    });
-
-                let text = he
-                    // encode special chars
-                    .encode(link.text, {
-                        useNamedReferences: true
-                    });
-
-                result.push(`<a href="${url}">${text}</a>`);
+                result.push(`<a href="${link.url}">${link.text}</a>`);
 
                 last = link.lastIndex;
             });


### PR DESCRIPTION
Avoid link urls double encoding in testToHtml function.