### PR TITLE
Resolved! Maximum call stack size exceeded in mailsplit

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
         "iconv-lite": "0.4.19",
         "libmime": "3.1.0",
         "linkify-it": "2.0.3",
-        "mailsplit": "4.0.2",
+        "mailsplit": "4.1.2",
         "tlds": "1.197.0"
     },
     "devDependencies": {


### PR DESCRIPTION
In the mailparser version 2.0.5/2.1.0

Issue :-
You have set the dependency of mailsplit module to (mailsplit@4.0.2) which is producing this error when it has to parse a failed attachment i.e an attachment of size <1kb and when I open that attachment in browser then it gives the below error :-

Assumption :-
Mail splitter is checking for chunk indefinately in recursion.

Error :-

`RangeError: Maximum call stack size exceeded,
    dir: /<project_path>/src,
    host: Subhash-H81M-S,
    Date: Wed Feb 07 2018 18:30:08 GMT+0530 (IST),
    Stack: RangeError: Maximum call stack size exceeded
at iterateData (/<project_path>/node_modules/mailparser/node_modules/mailsplit/lib/message-splitter.js:65:27)
at processLine (/<project_path>/node_modules/mailparser/node_modules/mailsplit/lib/message-splitter.js:79:36)
at MessageSplitter.processLine (/<project_path>/node_modules/mailparser/node_modules/mailsplit/lib/message-splitter.js:328:28)
at iterateData (/<project_path>/node_modules/mailparser/node_modules/mailsplit/lib/message-splitter.js:73:33)
at processLine (/<project_path>/node_modules/mailparser/node_modules/mailsplit/lib/message-splitter.js:79:36)
at MessageSplitter.processLine (/<project_path>/node_modules/mailparser/node_modules/mailsplit/lib/message-splitter.js:328:28)
at iterateData (/<project_path>/node_modules/mailparser/node_modules/mailsplit/lib/message-splitter.js:73:33)
at processLine (/<project_path>/node_modules/mailparser/node_modules/mailsplit/lib/message-splitter.js:79:36)
at MessageSplitter.processLine (/<project_path>/node_modules/mailparser/node_modules/mailsplit/lib/message-splitter.js:328:28)
at iterateData (/<project_path>/node_modules/mailparser/node_modules/mailsplit/lib/message-splitter.js:73:33)`



Fix :-
After I updated my mailsplit version to 4.1.2 the error is resolved. Kindly update the version of mail parser in the npm so that if somebody install mailparser he gets the updated version.