### PR TITLE
Only decode base64 encoded root-nodes if they are flowed

### DIFF
--- a/lib/mail-parser.js
+++ b/lib/mail-parser.js
@@ -413,7 +413,7 @@ class MailParser extends Transform {
             let decoder = node.getDecoder();
             if (
                 (/^text\//.test(contentType) && node.flowed) ||
-                (node.root && encoding === 'base64') // Handle emails with base64 encoded root node
+                (node.root && encoding === 'base64' && node.flowed) // Handle emails with base64 encoded root node
             ) {
                 let flowDecoder = decoder;
                 decoder = new FlowedDecoder({


### PR DESCRIPTION
Parser got stuck on trying to parse `smime.p7m` root nodes, and of course these encrypted parts should not be attempted to be decoded.