### PR TITLE
Decode root only when flowed (testcase)

### DIFF
--- a/lib/mail-parser.js
+++ b/lib/mail-parser.js
@@ -413,7 +413,7 @@ class MailParser extends Transform {
             let decoder = node.getDecoder();
             if (
                 (/^text\//.test(contentType) && node.flowed) ||
-                (node.root && encoding === 'base64') // Handle emails with base64 encoded root node
+                (node.root && encoding === 'base64' && node.flowed) // Handle emails with base64 encoded root node
             ) {
                 let flowDecoder = decoder;
                 decoder = new FlowedDecoder({

--- a/test/fixtures/base64encodedroot.eml
+++ b/test/fixtures/base64encodedroot.eml
@@ -1,0 +1,16 @@
+From: test@example.com
+Content-Type: image/png;
+ name="screenshot.png"
+Content-Transfer-Encoding: base64
+Content-Disposition: attachment;
+ filename="screenshot.png"
+
+iVBORw0KGgoAAAANSUhEUgAAABcAAAAfCAYAAAAMeVbNAAAABHNCSVQICAgIfAhkiAAAABl0
+RVh0U29mdHdhcmUAZ25vbWUtc2NyZWVuc2hvdO8Dvz4AAAE7SURBVEiJY/T3dfvPQCPARCuD
+Rw0fNXwoGM5rmckwoa+dId2ABau8kGUuw4S+doZkHezyeA2nBqCp4bj9RC7gkGOw8nFjsNdR
+prLhHMoMofkpDNZC3xkeXDlOyHBWBnGrYIZQlT8YMpxSghhi8u7BDNbinxlOzexjWHbzB2GX
+C6mYMlir4JL9jcSWYzDSFWNgeHec4dQzVgZeXlZChv9muL6olmHmBUyXC1nmMtSFSiEEOIQY
+xHgZGBhYLRlyGi0ZGBioGaEw+1+eZli24QLDJ+oa/o7h3WcGBgZOBoZPd28y3PhD1XT+jOH8
+jXcMDHwGDB52UgwsDFQ1/A/DnS1rGU69Y2VQ8MllqMtLoHIO/XGTYVlPH8OyY3cZPgspMzAO
+2dofa2qZ0NdDskEFRSUYYjR1+dAN81HDsQIA4N1NJ84wfR8AAAAASUVORK5CYII=
+


### PR DESCRIPTION
Added test case for when the root node is an attachment and should not be decoded by the flow decoder. Test case verifies the sha256 sum of the attachment.