### PR TITLE
Skip decoding for UTF-8

### DIFF
--- a/lib/mail-parser.js
+++ b/lib/mail-parser.js
@@ -704,9 +704,8 @@ class MailParser extends Transform {
                     if (
                         !['ascii', 'usascii', 'utf8'].includes(
                             charset
-                                .replace(/[^a-z0-9]+/g, '')
-                                .trim()
                                 .toLowerCase()
+                                .replace(/[^a-z0-9]+/g, '')
                         )
                     ) {
                         try {


### PR DESCRIPTION
Before the change, the regex would replace "UTF-8" with "-8" and cause unnecessary decoding.