### PR TITLE
Propagate errors for simpleParser

### DIFF
--- a/lib/simple-parser.js
+++ b/lib/simple-parser.js
@@ -24,6 +24,10 @@ module.exports = (input, options, callback) => {
 
     let parser = new MailParser(options);
 
+    parser.on('error', err => {
+        callback(err);
+    });
+
     parser.on('headers', headers => {
         mail.headers = headers;
         mail.headerLines = parser.headerLines;


### PR DESCRIPTION
If the simpleParser doesn't listen or errors for the underlying parser, the error will be uncaught.