### PR TITLE
fix: capture decoder end event to use on cleanup

### DIFF
--- a/lib/mail-parser.js
+++ b/lib/mail-parser.js
@@ -142,7 +142,8 @@ class MailParser extends Transform {
             this.push(t);
             done();
         };
-        if (this.curnode && this.curnode.decoder && this.curnode.decoder.readable) {
+        if (this.curnode && this.curnode.decoder && this.curnode.decoder.readable &&
+                !this.decoderEnded) {
             (this.curnode.contentStream || this.curnode.decoder).once('end', () => {
                 finish();
             });
@@ -427,7 +428,7 @@ class MailParser extends Transform {
                 });
                 flowDecoder.pipe(decoder);
             }
-
+            decoder.on('end', () => this.decoderEnded = true);
             newNode.decoder = decoder;
         }
 

--- a/test/fixtures/decoderended.eml
+++ b/test/fixtures/decoderended.eml
@@ -1,0 +1,40 @@
+Date: Sun, 9 Sep 2004 03:15:52 -0500
+From: wwuaof <booewq@uuui.com>
+Subject: Fwd: fotos
+To: dabadabadu <wwer@iiieww.net>
+Content-Type: multipart/mixed; boundary="0-328740690-1189354317=:31362"
+Content-Transfer-Encoding: 8bit
+MIME-Version: 1.0
+
+--0-328740690-1189354317=:31362
+Content-Type: multipart/alternative;
+	boundary="0-1554447476-1189354317=:31362"
+
+--0-1554447476-1189354317=:31362
+Content-Type: text/plain; charset="iso-8859-1"
+Content-Transfer-Encoding: 8bit
+
+
+
+Note: forwarded message attached.
+       
+---------------------------------
+Be a better something.
+Check it out.
+--0-1554447476-1189354317=:31362
+Content-Type: text/html; charset="iso-8859-1"
+Content-Transfer-Encoding: 8bit
+
+<span>html section</span>
+
+
+--0-1554447476-1189354317=:31362--
+
+--0-328740690-1189354317=:31362
+Content-Type: message/rfc822
+Content-Transfer-Encoding: 8bit
+
+--0-328740690-1189354317=:31362--
+
+--0-328740690-1189354317=:31362--
+

--- a/test/mail-parser-test.js
+++ b/test/mail-parser-test.js
@@ -1783,3 +1783,28 @@ exports['Attachment partId'] = {
         });
     }
 }
+
+exports['Decoder already ended on cleanup'] = test => {
+    let mail = fs.readFileSync(__dirname + '/fixtures/decoderended.eml');
+
+    test.expect(1);
+    let mailparser = new MailParser();
+
+    for (let i = 0, len = mail.length; i < len; i++) {
+        mailparser.write(Buffer.from([mail[i]]));
+    }
+    
+    mailparser.end();
+    let mailbodytext = null;
+    
+    mailparser.on('data', data => {                
+        if (data.type === 'text') {
+            mailbodytext = data.text;
+        }         
+    });
+    
+    mailparser.on('end', () => {        
+        test.equal('\n\nNote: forwarded message attached.\n       \n---------------------------------\nBe a better something.\nCheck it out.', mailbodytext);
+        test.done();
+    });
+};


### PR DESCRIPTION
Including a test case and example email which will cause the decoder to have already ended on cleanup, causing the `end` event to never fire - and the mailparser will not finish either.

Checking for `decoder.readable` is not sufficient to assure decoder has not already ended, so adding a handler for the `end` event, and checking for the result on cleanup.