### PR TITLE
Support encoded address lists.

### DIFF
--- a/lib/mail-parser.js
+++ b/lib/mail-parser.js
@@ -287,7 +287,7 @@ class MailParser extends Transform {
                 case 'reply-to':
                 case 'delivered-to':
                 case 'return-path':
-                    value = addressparser(value);
+                    value = addressparser(this.libmime.decodeWords(value));
                     this.decodeAddresses(value);
                     value = {
                         value,

--- a/test/mail-parser-test.js
+++ b/test/mail-parser-test.js
@@ -319,7 +319,7 @@ exports['Text encodings'] = {
     'Mime Words': test => {
         let encodedText =
                 'Content-type: text/plain; charset=utf-8\r\n' +
-                'From: =?utf-8?q?_?= <sender@email.com>\r\n' +
+                'From: =?utf-8?q?ender?= <sender@email.com>\r\n' +
                 'To: =?ISO-8859-1?Q?Keld_J=F8rn_Simonsen?= <to@email.com>\r\n' +
                 'Subject: =?iso-8859-1?Q?Avaldu?= =?iso-8859-1?Q?s_lepingu_?=\r\n =?iso-8859-1?Q?l=F5petamise?= =?iso-8859-1?Q?ks?=\r\n',
             mail = Buffer.from(encodedText, 'utf-8');
@@ -329,7 +329,7 @@ exports['Text encodings'] = {
         mailparser.on('data', () => false);
         mailparser.on('end', () => {
             test.equal(mailparser.subject, 'Avaldus lepingu lõpetamiseks');
-            test.equal(mailparser.from.value[0].name, ' ');
+            test.equal(mailparser.from.value[0].name, 'ender');
             test.equal(mailparser.to.value[0].name, 'Keld Jørn Simonsen');
             test.done();
         });
@@ -861,7 +861,7 @@ exports['Plaintext format'] = {
         mailparser.end(mail);
         mailparser.on('data', () => false);
         mailparser.on('end', () => {
-            test.equal(mailparser.text, 'How are you today?\n-- \nSignature\n');
+            test.equal(mailparser.text, 'How are you today?\n\n-- \nSignature\n');
             test.done();
         });
     },


### PR DESCRIPTION
use case header in which the entire name-and-address is all encoded in one block such as:

From: =?utf-8?B?IlJ5ZGVsIiA8UnlkZWxrYWxvdEAxN2d1YWd1YS5jb20+?=