### PR TITLE
fix(simple-parser): when input a gbk string, result has some garbled

### DIFF
--- a/lib/simple-parser.js
+++ b/lib/simple-parser.js
@@ -104,7 +104,7 @@ module.exports = (input, options, callback) => {
     });
 
     if (typeof input === 'string') {
-        parser.end(Buffer.from(new Uint8Array(input.split('').map(char => char.charCodeAt(0)))));
+        parser.end(Buffer.from(input, 'binary'));
     } else if (Buffer.isBuffer(input)) {
         parser.end(input);
     } else {

--- a/lib/simple-parser.js
+++ b/lib/simple-parser.js
@@ -104,7 +104,7 @@ module.exports = (input, options, callback) => {
     });
 
     if (typeof input === 'string') {
-        parser.end(Buffer.from(input));
+        parser.end(Buffer.from(new Uint8Array(input.split('').map(char => char.charCodeAt(0)))));
     } else if (Buffer.isBuffer(input)) {
         parser.end(input);
     } else {


### PR DESCRIPTION
Buffer.from(string) default encode is utf-8,when input string‘s encode is gbk,result has some garbled