### PR TITLE
Charset to lowercase before comparing

### DIFF
--- a/lib/mail-parser.js
+++ b/lib/mail-parser.js
@@ -52,7 +52,7 @@ class IconvDecoder extends Transform {
 
         // Iconv throws error on ks_c_5601-1987 when it is mapped to EUC-KR
         // https://github.com/bnoordhuis/node-iconv/issues/169
-        if (charset === 'ks_c_5601-1987') {
+        if (charset.toLowerCase() === 'ks_c_5601-1987') {
             charset = 'CP949';
         }
         this.stream = new Iconv(charset, 'UTF-8//TRANSLIT//IGNORE');


### PR DESCRIPTION
Iconv still throws error when charset is in uppercase KS_C_5601-1987
Convert to lowercase before comparing