### PR TITLE
Remove double decoding of header value via libmime, add test.

### DIFF
--- a/lib/mail-parser.js
+++ b/lib/mail-parser.js
@@ -356,7 +356,7 @@ class MailParser extends Transform {
                 case 'reply-to':
                 case 'delivered-to':
                 case 'return-path':
-                    value = addressparser(this.libmime.decodeWords(value));
+                    value = addressparser(value);
                     this.decodeAddresses(value);
                     value = {
                         value,

--- a/test/mail-parser-test.js
+++ b/test/mail-parser-test.js
@@ -333,6 +333,25 @@ exports['Text encodings'] = {
             test.equal(mailparser.to.value[0].name, 'Keld Jørn Simonsen');
             test.done();
         });
+    },
+
+    'Mime Words With Colon': test => {
+        let encodedText =
+		'Content-type: text/plain; charset=utf-8\r\n' +
+		'From: =?utf-8?Q?=3A.Good=20Test.=3A?= <sender@email.com>\r\n' +
+                'To: =?ISO-8859-1?Q?Keld_J=F8rn_Simonsen?= <to@email.com>\r\n' +
+		'Subject: =?iso-8859-1?Q?Avaldu?= =?iso-8859-1?Q?s_lepingu_?=\r\n =?iso-8859-1?Q?l=F5petamise?= =?iso-8859-1?Q?ks?=\r\n',
+            mail = Buffer.from(encodedText, 'utf-8');
+
+        let mailparser = new MailParser();
+        mailparser.end(mail);
+        mailparser.on('data', () => false);
+        mailparser.on('end', () => {
+            test.equal(mailparser.subject, 'Avaldus lepingu lõpetamiseks');
+            test.equal(mailparser.from.value[0].name, ':.Good Test.:');
+            test.equal(mailparser.to.value[0].name, 'Keld Jørn Simonsen');
+            test.done();
+        });
     }
 };
 


### PR DESCRIPTION
Fix the parsing of names that contain colons, i.e. ":.Example.: <example@example.com>"

When parsing an email with a From header of:

```
From: =?utf-8?Q?=3A.Good=20Test.=3A?= <example@example.com>
```

The address parser is passed a string that looks like:

`':.Good Test.: <example@example.com>'`

The use of the `:` character triggers address groups to be parsed.  This is incorrect.  This PR changes the behavior of the code to not decode the entire header value before passing it to the address parser.  Decoding of the parsed name will be performed by the `decodeAddresses` function.

