### PR TITLE
add and use new config option to specify whether carriage returns should be preserved in text and html parts, or not

### DIFF
--- a/lib/mail-parser.js
+++ b/lib/mail-parser.js
@@ -904,9 +904,9 @@ class MailParser extends Transform {
                     });
 
                     node.contentStream.once('end', () => {
-                        node.textContent = Buffer.concat(chunks, chunklen)
-                            .toString()
-                            .replace(/\r?\n/g, '\n');
+                      node.textContent = this.options.preserveCarriages ? 
+                                          Buffer.concat(chunks, chunklen).toString() : 
+                                          Buffer.concat(chunks, chunklen).toString().replace(/\r?\n/g, '\n');
                     });
 
                     node.contentStream.once('error', err => {

--- a/package.json
+++ b/package.json
@@ -1,50 +1,49 @@
 {
-    "name": "mailparser",
-    "version": "2.7.7",
-    "description": "Parse e-mails",
-    "main": "index.js",
-    "scripts": {
-        "test": "grunt"
-    },
-    "author": "Andris Reinman",
-    "contributors": [
-        {
-            "name": "Peter Salomonsen",
-            "email": "petersalomonsen@runbox.com",
-            "url": "https://github.com/petersalomonsen"
-        }
-    ],
-    "license": "(MIT OR EUPL-1.1+)",
-    "dependencies": {
-        "encoding-japanese": "1.0.30",
-        "he": "1.2.0",
-        "html-to-text": "5.1.1",
-        "iconv-lite": "0.6.0",
-        "libmime": "4.2.1",
-        "linkify-it": "3.0.2",
-        "mailsplit": "5.0.0",
-        "nodemailer": "6.4.8",
-        "tlds": "1.207.0"
-    },
-    "devDependencies": {
-        "ajv": "6.12.2",
-        "eslint": "7.2.0",
-        "eslint-config-nodemailer": "1.2.0",
-        "eslint-config-prettier": "6.11.0",
-        "grunt": "1.1.0",
-        "grunt-cli": "1.3.2",
-        "grunt-contrib-nodeunit": "2.1.0",
-        "grunt-eslint": "23.0.0",
-        "iconv": "3.0.0",
-        "libbase64": "1.2.1",
-        "libqp": "1.1.0",
-        "random-message": "1.1.0"
-    },
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/nodemailer/mailparser.git"
-    },
-    "bugs": {
-        "url": "https://github.com/nodemailer/mailparser/issues"
-    }
+  "name": "@calipsa/mailparser",
+  "version": "0.0.1",
+  "description": "Parse e-mails",
+  "main": "index.js",
+  "scripts": {
+    "test": "grunt"
+  },
+  "author": "Usama Ashraf",
+  "license": "(MIT OR EUPL-1.1+)",
+  "dependencies": {
+    "encoding-japanese": "1.0.30",
+    "he": "1.2.0",
+    "html-to-text": "5.1.1",
+    "iconv-lite": "0.6.0",
+    "libmime": "4.2.1",
+    "linkify-it": "3.0.2",
+    "mailsplit": "5.0.0",
+    "nodemailer": "6.4.8",
+    "tlds": "1.207.0"
+  },
+  "devDependencies": {
+    "ajv": "6.12.2",
+    "eslint": "7.2.0",
+    "eslint-config-nodemailer": "1.2.0",
+    "eslint-config-prettier": "6.11.0",
+    "grunt": "1.1.0",
+    "grunt-cli": "1.3.2",
+    "grunt-contrib-nodeunit": "2.1.0",
+    "grunt-eslint": "23.0.0",
+    "iconv": "3.0.0",
+    "libbase64": "1.2.1",
+    "libqp": "1.1.0",
+    "random-message": "1.1.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/calipsa/mailparser.git"
+  },
+  "bugs": {
+    "url": "https://github.com/calipsa/mailparser/issues"
+  },
+  "homepage": "https://github.com/calipsa//mailparser#readme",
+  "directories": {
+    "example": "examples",
+    "lib": "lib",
+    "test": "test"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/calipsa/mailparser.git"
+    "url": "https://github.com/calipsa/mailparser.git"
   },
   "bugs": {
     "url": "https://github.com/calipsa/mailparser/issues"


### PR DESCRIPTION
In the interest of preserving originality, if strictly needed. I've come across use-cases where I've had to forward an email almost exactly as it came in and only modifying a few, say, attachments. To send the same html, text parts back the legacy `\r\n` may need to be retained, otherwise certain servers/programs may have a hard time parsing the email that is forwarded back. 