### PR TITLE
Fix invalid date checking

### DIFF
--- a/lib/mail-parser.js
+++ b/lib/mail-parser.js
@@ -315,7 +315,7 @@ class MailParser extends Transform {
                     break;
                 case 'date':
                     value = new Date(value);
-                    if (!value || value.toString() === 'Invalid Date' || !value.getTime()) {
+                    if (isNaN(value)) {
                         // date parsing failed :S
                         value = new Date();
                     }


### PR DESCRIPTION
`value.getTime()` yields 0 for `new Date(0)` which is a valid date.

```
> isNaN(new Date(0))
false
> isNaN(new Date(1))
false
> isNaN(new Date('Thu, 01 Jan 1970 00:00:00 +0000'))
false
> isNaN(new Date('not a date'))
true
```