### PR TITLE
Fix unhandled exception due to invalid punycode in address strings

### DIFF
--- a/lib/mail-parser.js
+++ b/lib/mail-parser.js
@@ -527,9 +527,13 @@ class MailParser extends Transform {
                 }
             }
             if (/@xn--/.test(address.address)) {
-                address.address =
-                    address.address.substr(0, address.address.lastIndexOf('@') + 1) +
-                    punycode.toUnicode(address.address.substr(address.address.lastIndexOf('@') + 1));
+                try {
+                    address.address =
+                        address.address.substr(0, address.address.lastIndexOf('@') + 1) +
+                        punycode.toUnicode(address.address.substr(address.address.lastIndexOf('@') + 1));
+                } catch (E) {
+                    // Not a valid punycode string; keep as is
+                }
             }
             if (address.group) {
                 this.decodeAddresses(address.group);

--- a/test/mail-parser-test.js
+++ b/test/mail-parser-test.js
@@ -352,6 +352,38 @@ exports['Text encodings'] = {
             test.equal(mailparser.to.value[0].name, 'Keld Jørn Simonsen');
             test.done();
         });
+    },
+
+    'Punycode Address': test => {
+        let encodedText =
+                'From: "Sender <sender@xn--mnchen-ost-9db.test.fm>\r\n' +
+                'To: "Test Recipient" <to@email.com>\r\n',
+            mail = Buffer.from(encodedText, 'utf-8');
+
+        let mailparser = new MailParser();
+        mailparser.end(mail);
+        mailparser.on('data', () => false);
+        mailparser.on('end', () => {
+            test.equal(mailparser.from.value[0].address, 'sender@münchen-ost.test.fm');
+            test.equal(mailparser.to.value[0].address, 'to@email.com');
+            test.done();
+        });
+    },
+
+    'Punycode Address: Invalid': test => {
+        let encodedText =
+                'From: "Postmaster <postmaster@xn--mnchen-ost-9db-test-fm.bounce-mta.com>\r\n' +
+                'To: "Test Recipient" <to@email.com>\r\n',
+            mail = Buffer.from(encodedText, 'utf-8');
+
+        let mailparser = new MailParser();
+        mailparser.end(mail);
+        mailparser.on('data', () => false);
+        mailparser.on('end', () => {
+            test.equal(mailparser.from.value[0].address, 'postmaster@xn--mnchen-ost-9db-test-fm.bounce-mta.com');
+            test.equal(mailparser.to.value[0].address, 'to@email.com');
+            test.done();
+        });
     }
 };
 


### PR DESCRIPTION
When the `punycode` library tries to decode a domain name string that's encoded incorrectly, it throws `Error("Invalid input")`. 

This can happen if a punycode string is modified and reused by an MTA without knowing the encoding -- For example, if an email to `<someone@domain.com>` bounces, often the bounce notification's `From:` header will contain an address like `<postmaster@domain-com.mta.net>`. If the original address contained a punycode string, the transformed string will often look like punycode (starts with `xn--`) but won't decode properly.

I followed the pattern currently used to handle invalid address name strings in `decodeAddresses`: Try to decode the punycode string as before, but if it can't be decoded without crashing, use the address as-is.

Added unit tests to cover the success + failure cases for this bug.