### PR TITLE
Fix #272: Throw TypeError for invalid input.

### DIFF
--- a/lib/simple-parser.js
+++ b/lib/simple-parser.js
@@ -3,6 +3,10 @@
 const MailParser = require('./mail-parser.js');
 
 module.exports = (input, options, callback) => {
+    if (input === null || input === undefined) {
+        throw new TypeError('Input cannot be null or undefined.')
+    }
+
     if (!callback && typeof options === 'function') {
         callback = options;
         options = false;

--- a/test/issue-272-test.js
+++ b/test/issue-272-test.js
@@ -1,0 +1,45 @@
+'use strict';
+
+const simpleParser = require('..').simpleParser;
+
+module.exports['Throws TypeError with input === null'] = async test => {
+
+  try {
+    simpleParser(null);
+
+    throw Error('Error not thrown.');
+  } catch (error) {
+    test.equal(error.constructor.name, 'TypeError');
+  }
+
+  test.done();
+
+};
+
+module.exports['Throws TypeError with input === undefined'] = async test => {
+
+  try {
+    simpleParser(undefined);
+
+    throw Error('Error not thrown.');
+  } catch (error) {
+    test.equal(error.constructor.name, 'TypeError');
+  }
+
+  test.done();
+
+};
+
+module.exports['Throws TypeError without input'] = async test => {
+
+  try {
+    simpleParser();
+
+    throw Error('Error not thrown.');
+  } catch (error) {
+    test.equal(error.constructor.name, 'TypeError');
+  }
+
+  test.done();
+
+};


### PR DESCRIPTION
`simpleParser` does not throw an exception when its first parameter, 'input', is null or undefined. Instead, it fails in the middle of the execution when trying to evaluate `input.once`, which is not defined on null/undefined.

Also added related unit tests.

Closes #272 