### PR TITLE
Update package.json nodemailer to remove vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
         "libmime": "5.0.0",
         "linkify-it": "3.0.2",
         "mailsplit": "5.0.1",
-        "nodemailer": "6.4.16",
+        "nodemailer": "6.6.3",
         "tlds": "1.219.0"
     },
     "devDependencies": {


### PR DESCRIPTION
What does this PR do? 

- Upgrade nodemailer to 6.6.3 to avoid `HTTP Header Injection` https://snyk.io/vuln/npm:nodemailer

Release a new version of `mailparser` will be also needed to propagate the fix. 