### PR TITLE
fix node 18 breakage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,26 @@
+on: push
+
+jobs:
+  test:
+    name: test
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        node: [^12, ^14, ^16, ^18]
+        os: [ubuntu-latest, windows-latest, macos-latest]
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+
+      - name: node
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node }}
+
+      - name: install
+        run: npm install
+
+      - name: test
+        run: npm test

--- a/lib/mail-parser.js
+++ b/lib/mail-parser.js
@@ -138,7 +138,6 @@ class MailParser extends Transform {
 
         this.endReceived = false;
         this.reading = false;
-        this.errored = false;
 
         this.tree = false;
         this.curnode = false;
@@ -175,7 +174,6 @@ class MailParser extends Transform {
         });
 
         this.splitter.on('error', err => {
-            this.errored = true;
             if (typeof this.waitingEnd === 'function') {
                 return this.waitingEnd(err);
             }


### PR DESCRIPTION
setting the `errored` property is a fatal operation under node 18. removing the offending lines seems to make no difference for the tests. i've added a github actions workflow for running the tests under various nodes.

depends on https://github.com/nodemailer/smtp-server/pull/176 being merged & published