### PR TITLE
chore: bump libmime from 5.1.0 to 5.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
         "he": "1.2.0",
         "html-to-text": "8.2.0",
         "iconv-lite": "0.6.3",
-        "libmime": "5.1.0",
+        "libmime": "5.2.0",
         "linkify-it": "4.0.0",
         "mailsplit": "5.3.2",
         "nodemailer": "6.7.3",


### PR DESCRIPTION
Related to [https://github.com/nodemailer/libmime/pull/13](https://github.com/nodemailer/libmime/pull/13)