### PR TITLE
Fix produced text address list string according to rfc 2822

### DIFF
--- a/lib/mail-parser.js
+++ b/lib/mail-parser.js
@@ -1015,7 +1015,7 @@ class MailParser extends Transform {
                 .map(address => {
                     let str = '';
                     if (address.name) {
-                        str += address.name + (address.group ? ': ' : '');
+                        str += `"${address.name}"` + (address.group ? ': ' : '');
                     }
                     if (address.address) {
                         let link = address.address;

--- a/test/simple-parser-test.js
+++ b/test/simple-parser-test.js
@@ -25,7 +25,7 @@ module.exports['Parse message'] = test => {
                 }
             ],
             html: '<span class="mp_address_group"><span class="mp_address_name">Andris Reinman</span> &lt;<a href="mailto:andris+123@kreata.ee" class="mp_address_email">andris+123@kreata.ee</a>&gt;</span>, <span class="mp_address_group"><a href="mailto:andris.reinman@gmail.com" class="mp_address_email">andris.reinman@gmail.com</a></span>',
-            text: 'Andris Reinman <andris+123@kreata.ee>, andris.reinman@gmail.com'
+            text: '"Andris Reinman" <andris+123@kreata.ee>, andris.reinman@gmail.com'
         });
         test.done();
     });


### PR DESCRIPTION
A.1.2. Different types of mailboxes

   This message includes multiple addresses in the destination fields
   and also uses several different forms of addresses.

----
From: "Joe Q. Public" <john.q.public@example.com>
To: Mary Smith <mary@x.test>, jdoe@example.org, Who? <one@y.test>
Cc: <boss@nil.test>, "Giant; \"Big\" Box" <sysservices@example.net>
Date: Tue, 1 Jul 2003 10:52:37 +0200
Message-ID: <5678.21-Nov-1997@example.com>

Hi everyone.
----

   Note that the display names for Joe Q. Public and Giant; "Big" Box
   needed to be enclosed in double-quotes because the former contains
   the period and the latter contains both semicolon and double-quote
   characters (the double-quote characters appearing as quoted-pair
   construct).  Conversely, the display name for Who? could appear
   without them because the question mark is legal in an atom.  Notice
   also that jdoe@example.org and boss@nil.test have no display names
   associated with them at all, and jdoe@example.org uses the simpler
   address form without the angle brackets.






Another try to fix text string generation :-)