### PR TITLE
Parse disposition-notification-to header as address

### DIFF
--- a/lib/mail-parser.js
+++ b/lib/mail-parser.js
@@ -365,6 +365,7 @@ class MailParser extends Transform {
                 case 'reply-to':
                 case 'delivered-to':
                 case 'return-path':
+                case 'disposition-notification-to':
                     value = addressparser(value);
                     this.decodeAddresses(value);
                     value = {
@@ -409,7 +410,8 @@ class MailParser extends Transform {
             'mime-version',
             'content-description',
             'precedence',
-            'errors-to'
+            'errors-to',
+            'disposition-notification-to'
         ];
 
         headers.forEach((value, key) => {


### PR DESCRIPTION
In our application we need to handle MDNs and for that we need to parse the "Disposition-Notification-To" header and compare the address with the Return-Path header.

I would like to have the same structure of addresses and use mail parser function, but it feels quite dirty to use undocumented and seemingly internal-only methods like `decodeAddresses`, `getAddressesHTML` and `getAddressesText`, so I decided to add a small PR in the hopes that it will be accepted and merged in a timely manner.

Unfortunately I do not have the time (and quite frankly the knowledge) to implement all the parsing related to MDNs (e.g. machine readable and human readable content for an MDN mail).

