### PR TITLE
Bump `nodemailer` dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
                 "libmime": "5.3.7",
                 "linkify-it": "5.0.0",
                 "mailsplit": "5.4.6",
-                "nodemailer": "7.0.5",
+                "nodemailer": "7.0.9",
                 "punycode.js": "2.3.1",
                 "tlds": "1.259.0"
             },
@@ -3031,9 +3031,10 @@
             "dev": true
         },
         "node_modules/nodemailer": {
-            "version": "7.0.5",
-            "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-7.0.5.tgz",
-            "integrity": "sha512-nsrh2lO3j4GkLLXoeEksAMgAOqxOv6QumNRVQTJwKH4nuiww6iC2y7GyANs9kRAxCexg3+lTWM3PZ91iLlVjfg==",
+            "version": "7.0.9",
+            "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-7.0.9.tgz",
+            "integrity": "sha512-9/Qm0qXIByEP8lEV2qOqcAW7bRpL8CR9jcTwk3NBnHJNmP9fIJ86g2fgmIXqHY+nj55ZEMwWqYAT2QTDpRUYiQ==",
+            "license": "MIT-0",
             "engines": {
                 "node": ">=6.0.0"
             }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
         "libmime": "5.3.7",
         "linkify-it": "5.0.0",
         "mailsplit": "5.4.6",
-        "nodemailer": "7.0.5",
+        "nodemailer": "7.0.9",
         "punycode.js": "2.3.1",
         "tlds": "1.259.0"
     },


### PR DESCRIPTION
Bumps the vulnerable `nodemailer` dependency to be > 7.07
Per: https://github.com/advisories/GHSA-mm7p-fcc7-pg87