### PR TITLE
chore: rename mailsplit to @zone-eu/mailsplit

### DIFF
--- a/lib/mail-parser.js
+++ b/lib/mail-parser.js
@@ -1,13 +1,13 @@
 'use strict';
 
-const mailsplit = require('mailsplit');
+const mailsplit = require('@zone-eu/mailsplit');
 const libmime = require('libmime');
 const addressparser = require('nodemailer/lib/addressparser');
 const Transform = require('stream').Transform;
 const Splitter = mailsplit.Splitter;
 const ChunkedPassthrough = mailsplit.ChunkedPassthrough;
 const punycode = require('punycode.js');
-const FlowedDecoder = require('mailsplit/lib/flowed-decoder');
+const FlowedDecoder = require('@zone-eu/mailsplit/lib/flowed-decoder');
 const StreamHash = require('./stream-hash');
 const iconv = require('iconv-lite');
 const { htmlToText } = require('html-to-text');

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,13 +9,13 @@
             "version": "3.7.5",
             "license": "MIT",
             "dependencies": {
+                "@zone-eu/mailsplit": "5.4.7",
                 "encoding-japanese": "2.2.0",
                 "he": "1.2.0",
                 "html-to-text": "9.0.5",
                 "iconv-lite": "0.7.0",
                 "libmime": "5.3.7",
                 "linkify-it": "5.0.0",
-                "mailsplit": "5.4.6",
                 "nodemailer": "7.0.9",
                 "punycode.js": "2.3.1",
                 "tlds": "1.260.0"
@@ -594,6 +594,17 @@
             "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
             "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
             "dev": true
+        },
+        "node_modules/@zone-eu/mailsplit": {
+            "version": "5.4.7",
+            "resolved": "https://registry.npmjs.org/@zone-eu/mailsplit/-/mailsplit-5.4.7.tgz",
+            "integrity": "sha512-jApX86aDgolMz08pP20/J2zcns02NSK3zSiYouf01QQg4250L+GUAWSWicmS7eRvs+Z7wP7QfXrnkaTBGrIpwQ==",
+            "license": "(MIT OR EUPL-1.1+)",
+            "dependencies": {
+                "libbase64": "1.3.0",
+                "libmime": "5.3.7",
+                "libqp": "2.1.1"
+            }
         },
         "node_modules/abbrev": {
             "version": "1.1.1",
@@ -2939,17 +2950,6 @@
             "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
             "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
             "dev": true
-        },
-        "node_modules/mailsplit": {
-            "version": "5.4.6",
-            "resolved": "https://registry.npmjs.org/mailsplit/-/mailsplit-5.4.6.tgz",
-            "integrity": "sha512-M+cqmzaPG/mEiCDmqQUz8L177JZLZmXAUpq38owtpq2xlXlTSw+kntnxRt2xsxVFFV6+T8Mj/U0l5s7s6e0rNw==",
-            "license": "(MIT OR EUPL-1.1+)",
-            "dependencies": {
-                "libbase64": "1.3.0",
-                "libmime": "5.3.7",
-                "libqp": "2.1.1"
-            }
         },
         "node_modules/make-dir": {
             "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
         "iconv-lite": "0.7.0",
         "libmime": "5.3.7",
         "linkify-it": "5.0.0",
-        "mailsplit": "5.4.6",
+        "@zone-eu/mailsplit": "5.4.7",
         "nodemailer": "7.0.9",
         "punycode.js": "2.3.1",
         "tlds": "1.260.0"


### PR DESCRIPTION
Due to renaming of mailsplit, it gets flagged as deprecated.

Fixes:
https://github.com/nodemailer/mailparser/issues/400
https://github.com/nodemailer/mailparser/issues/399