### PR TITLE
bump nodemailer version to fix data uri size limit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
                 "libmime": "5.3.7",
                 "linkify-it": "5.0.0",
                 "mailsplit": "5.4.6",
-                "nodemailer": "7.0.9",
+                "nodemailer": "7.0.10",
                 "punycode.js": "2.3.1",
                 "tlds": "1.260.0"
             },
@@ -3075,9 +3075,9 @@
             "license": "MIT"
         },
         "node_modules/nodemailer": {
-            "version": "7.0.9",
-            "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-7.0.9.tgz",
-            "integrity": "sha512-9/Qm0qXIByEP8lEV2qOqcAW7bRpL8CR9jcTwk3NBnHJNmP9fIJ86g2fgmIXqHY+nj55ZEMwWqYAT2QTDpRUYiQ==",
+            "version": "7.0.10",
+            "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-7.0.10.tgz",
+            "integrity": "sha512-Us/Se1WtT0ylXgNFfyFSx4LElllVLJXQjWi2Xz17xWw7amDKO2MLtFnVp1WACy7GkVGs+oBlRopVNUzlrGSw1w==",
             "license": "MIT-0",
             "engines": {
                 "node": ">=6.0.0"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
         "libmime": "5.3.7",
         "linkify-it": "5.0.0",
         "mailsplit": "5.4.6",
-        "nodemailer": "7.0.9",
+        "nodemailer": "7.0.10",
         "punycode.js": "2.3.1",
         "tlds": "1.260.0"
     },


### PR DESCRIPTION
Hello,

First, a big thanks for the great lib

This commit just increases the nodemailer version to 7.0.10 in order to include that fix: https://github.com/nodemailer/nodemailer/commit/28dbf3fe129653f5756c150a98dc40593bfb2cfe

I ran the tests locally beforehand.

Thanks!