### PR TITLE
fix: decode iso-8859-8-i and iso-8859-8-e charsets as iso-8859-8

### DIFF
--- a/lib/mail-parser.js
+++ b/lib/mail-parser.js
@@ -212,6 +212,11 @@ class MailParser extends Transform {
                         return new JPDecoder(charset);
                     }
 
+                    if (/^iso-?8859-?8-?[ie]$/i.test(charset)) {
+                        // iso-8859-8-i/-e are just iso-8859-8
+                        charset = 'iso-8859-8';
+                    }
+
                     return iconv.decodeStream(charset);
                 }
             };

--- a/test/simple-parser-test.js
+++ b/test/simple-parser-test.js
@@ -113,6 +113,26 @@ Subject: =?ISO-2022-JP?B?GyRCM1g5OzU7PVEwdzgmPSQ4IUYkMnFKczlwGyhC?=
     });
 };
 
+module.exports['Parse iso-8859-8-i charset'] = test => {
+    let source = Buffer.concat([
+        Buffer.from(`Content-Type: text/plain; charset="iso-8859-8-i"
+
+`),
+        Buffer.from('+ezl7SDy5ezt', 'base64')
+    ]);
+
+    let expected = 'שלום עולם';
+
+    simpleParser(source, {}, (err, mail) => {
+        test.ifError(err);
+        test.ok(mail);
+        test.equal(mail.text.trim(), expected);
+        test.ok(!mail.text.includes('\uFFFD'));
+
+        test.done();
+    });
+};
+
 module.exports['Parse encoded address string'] = test => {
     let source = Buffer.from(
         `From: test@example.com


### PR DESCRIPTION
Hey there!

We use Mailparser at Crisp and got a report from a customer who received glitchy emails.

We discovered Hebrew email bodies declared as charset="iso-8859-8-i" (or -e) are emitting U+FFFD because iconv-lite is not mapping those charsets properly.

I added a mapping to use iso-8859-8 instead, and it works fine.

Tests have been updated as well.