### PR TITLE
fix(deps): bump html-to-text to 10.0.1 to resolve deepmerge-ts CVE

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
                 "@zone-eu/mailsplit": "5.4.15",
                 "encoding-japanese": "2.2.0",
                 "he": "1.2.0",
-                "html-to-text": "10.0.0",
+                "html-to-text": "10.0.1",
                 "iconv-lite": "0.7.3",
                 "libmime": "5.4.2",
                 "linkify-it": "5.0.2",
@@ -1315,9 +1315,19 @@
             "license": "MIT"
         },
         "node_modules/deepmerge-ts": {
-            "version": "7.1.5",
-            "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-7.1.5.tgz",
-            "integrity": "sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==",
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-8.0.1.tgz",
+            "integrity": "sha512-szCXE7YLCvLKR9bFPJcvsezOShdalctSvrgN/LM/QGUEPZQajwjmsMObZ6/DuANT5lxzM/wtO8Feubwdkz8myA==",
+            "funding": [
+                {
+                    "type": "ko-fi",
+                    "url": "https://ko-fi.com/rebeccastevens"
+                },
+                {
+                    "type": "tidelift",
+                    "url": "https://tidelift.com/funding/github/npm/deepmerge-ts"
+                }
+            ],
             "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=16.0.0"
@@ -2744,13 +2754,13 @@
             "license": "MIT"
         },
         "node_modules/html-to-text": {
-            "version": "10.0.0",
-            "resolved": "https://registry.npmjs.org/html-to-text/-/html-to-text-10.0.0.tgz",
-            "integrity": "sha512-2OH59Gtprdczel+7Rxgpz9hGVJREaf8Lt1H4kZwWHpEn70VQKRuMNGsb2eDbwaTzrYzb0hheiOG1P7Dim0B4dQ==",
+            "version": "10.0.1",
+            "resolved": "https://registry.npmjs.org/html-to-text/-/html-to-text-10.0.1.tgz",
+            "integrity": "sha512-GiVhRI1BatGARSCmlXWNCjDT0cWrwBWoeduLoV0WSKAgaV/wa+hUWy5LiQLUs4UwiUrE52ZCMfBGiKD87TDPrg==",
             "license": "MIT",
             "dependencies": {
                 "@selderee/plugin-htmlparser2": "~0.12.0",
-                "deepmerge-ts": "^7.1.5",
+                "deepmerge-ts": "^8.0.1",
                 "dom-serializer": "^2.0.0",
                 "htmlparser2": "^10.1.0",
                 "selderee": "~0.12.0"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "dependencies": {
         "encoding-japanese": "2.2.0",
         "he": "1.2.0",
-        "html-to-text": "10.0.0",
+        "html-to-text": "10.0.1",
         "iconv-lite": "0.7.3",
         "libmime": "5.4.2",
         "linkify-it": "5.0.2",


### PR DESCRIPTION
Hello - while resolving some security issues, I noticed this would be easy to fix. 

## Summary
- Bumps `html-to-text` from `10.0.0` to `10.0.1`.
- `10.0.1` is a dependency-only security release: it bumps `html-to-text`'s own `deepmerge-ts` dependency from `^7.1.5` to `^8.0.1`, fixing a stack exhaustion vulnerability when merging recursive object graphs ([GHSA-ggr8-5vv4-36mx](https://github.com/advisories/GHSA-ggr8-5vv4-36mx)).
- No other code changes between `html-to-text` 10.0.0 and 10.0.1.
- Kept the existing exact-version pin style (`"10.0.1"` rather than `"^10.0.1"`) to match how every other dependency in this `package.json` is pinned, rather than switching to a range.

Fixes #432

## Test plan
- [x] `npm install` resolves `deepmerge-ts` to `8.0.1`.
- [x] `npm audit` no longer flags `deepmerge-ts`.
- [x] Full test suite (`npm test` — eslint + nodeunit) passes: 253/253 assertions, identical to the pre-change baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)